### PR TITLE
Feat/game 70 Настроить docker для postgress

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,5 +38,32 @@ services:
         POSTGRES_USER: ${POSTGRES_USER}
         POSTGRES_DB: ${POSTGRES_DB}
       volumes:
+        - ./migrations/dbinit.sql:/docker-entrypoint-initdb.d/dbinit.sql
         - ./tmp/pgdata:/var/lib/postgresql/data
+      networks:
+        - team09
+
+    pgadmin:
+      container_name: pgadmin
+      image: dpage/pgadmin4:4.18
+      restart: always
+      environment:
+        PGADMIN_DEFAULT_EMAIL: demo@demo.com
+        PGADMIN_DEFAULT_PASSWORD: secret
+        PGADMIN_LISTEN_PORT: 80
+      ports:
+        - "8080:80"
+      volumes:
+        - pgadmin-data:/var/lib/pgadmin
+      depends_on:
+        - postgres
+      networks:
+        - team09
+
+volumes:
+  pgadmin-data:
+
+networks:
+  team09:
+    driver: bridge
 

--- a/migrations/dbinit.sql
+++ b/migrations/dbinit.sql
@@ -1,0 +1,22 @@
+CREATE TABLE categories (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    posts_count INTEGER NOT NULL default 0,
+    last_message INTEGER,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL default NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL default NOW()
+);
+
+CREATE TABLE topics (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    author INTEGER,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL default NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL default NOW(),
+    parent_id INTEGER,
+    CONSTRAINT parent_fk FOREIGN KEY (parent_id) REFERENCES categories (id)
+);
+
+INSERT INTO categories (name, description) VALUES ('Сообщество', 'Обсуждение игры'), ('Поддержка', 'Возникли затруднения с установкой игры, игровым процессом или учетной записью? Приглашаем на форум службы поддержки.');
+INSERT INTO topics (name, parent_id) VALUES ('Тема 111', 1), ('Тема 222', 2);


### PR DESCRIPTION
### GAME-70 Настроить docker для postgress

Добавил pgadmin и несколько демо таблиц для изначальной инициализации

Для начала нужно удалить папку tmp/pgdata
Запуск posteges - docker-compose up -d postgres
Запуск pgamin - docker-compose up -d pgadmin

pgadmin работает по адресу http://localhost:8080/
Доступы demo@demo.com : secret
Далее нужно добавить базу по доступам из .env

![Screenshot_2](https://github.com/24-team-09/Arcade-2D-game/assets/83064000/cbc69b21-1a5c-4c86-b4c4-806aaf88abae)
